### PR TITLE
Fix handler for external keyboard inputs with `SubWebViewFragment`

### DIFF
--- a/app/src/main/java/net/twinte/android/SubWebViewFragment.kt
+++ b/app/src/main/java/net/twinte/android/SubWebViewFragment.kt
@@ -5,7 +5,6 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -110,19 +109,18 @@ class SubWebViewFragment : BottomSheetDialogFragment() {
         }
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialog = super.onCreateDialog(savedInstanceState)
-        dialog.setOnKeyListener { _, code, event ->
-            if (event.action != KeyEvent.ACTION_UP) return@setOnKeyListener true
-
-            if (code == KeyEvent.KEYCODE_BACK && sub_webview.canGoBack())
-                sub_webview.goBack()
-            else dialog.dismiss()
-
-            return@setOnKeyListener true
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+        object : BottomSheetDialog(requireContext(), theme) {
+            override fun onBackPressed() {
+                if (sub_webview.canGoBack()) {
+                    // ダイアログで表示されているページから一つ前のページに戻れる場合、そこに戻る
+                    sub_webview.goBack()
+                } else {
+                    // ダイアログで表示されているページの前にはページが無い場合、ダイアログを閉じる
+                    dismiss()
+                }
+            }
         }
-        return dialog
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_sub_webview, container, false)


### PR DESCRIPTION
# 概要

closes #21

外付けキーボードで Twitter ログイン時などに入力しようとした際にダイアログが閉じてしまうのを修正します。

## 動作確認

- 実機（Pixel 6a, Android 13）で画面上のキーボードにて Twitter ログインができること
  - エミュレータからホストのキーボードで入力した際も同様に確認済み
  - 実機に外付けキーボードを接続した際も同様に確認済み
- 実機で back press をしたとき、表示されている WebView に前のページがあるならばそこに戻ること
- 実機で back press をしたとき、表示されている WebView に前のページがなければダイアログが閉じること
  - エミュレータで back press をしたときも同様に確認済み