### PR TITLE
Provide minimum hygiene for further development

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,5 @@
 /dataSources.local.xml
 # Editor-based HTTP Client requests
 /httpRequests/
+
+deploymentTargetDropDown.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+TwinteAndroid

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,16 +1,8 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
-    <XML>
-      <option name="XML_KEEP_LINE_BREAKS" value="false" />
-      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-      <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
-    </XML>
     <codeStyleSettings language="XML">
       <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
@@ -125,15 +117,7 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CALL_PARAMETERS_WRAP" value="5" />
-      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_WRAP" value="5" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="EXTENDS_LIST_WRAP" value="1" />
-      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-      <option name="ASSIGNMENT_WRAP" value="1" />
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -12,14 +12,14 @@
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
     <remote-repository>
-      <option name="id" value="BintrayJCenter" />
-      <option name="name" value="BintrayJCenter" />
-      <option name="url" value="https://jcenter.bintray.com/" />
-    </remote-repository>
-    <remote-repository>
       <option name="id" value="Google" />
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.6.21" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion(31)
+    compileSdkVersion(33)
 
     defaultConfig {
         applicationId = "net.twinte.android"
@@ -42,7 +42,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
     implementation("androidx.core:core-ktx:1.6.0")
     implementation("androidx.appcompat:appcompat:1.3.1")
-    implementation("androidx.work:work-runtime-ktx:2.6.0")
+    implementation("androidx.work:work-runtime-ktx:2.8.1")
     implementation("com.google.android.material:material:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.0")
     implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     compileSdkVersion(30)
-    buildToolsVersion = "30.0.2"
 
     defaultConfig {
         applicationId = "net.twinte.android"
@@ -34,6 +33,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    namespace = "net.twinte.android"
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdkVersion(31)
 
     defaultConfig {
         applicationId = "net.twinte.android"
         minSdkVersion(23)
-        targetSdkVersion (30)
+        targetSdkVersion (31)
         versionCode = 19
         versionName = "2.0.3"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.twinte.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.Splash">
+            android:theme="@style/AppTheme.Splash"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -32,7 +33,8 @@
         <!--    小ウィジット    -->
         <receiver
             android:name=".widget.V3SmallWidgetProvider"
-            android:label="@string/widget_small_label">
+            android:label="@string/widget_small_label"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -43,7 +45,8 @@
         <!--    中ウィジット    -->
         <receiver
             android:name=".widget.V3MediumWidgetProvider"
-            android:label="@string/widget_medium_label">
+            android:label="@string/widget_medium_label"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -54,7 +57,8 @@
         <!--    大ウィジット    -->
         <receiver
             android:name=".widget.V3LargeWidgetProvider"
-            android:label="@string/widget_large_label">
+            android:label="@string/widget_large_label"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -64,7 +68,8 @@
         </receiver>
 
         <!--    スマホ再起動時 / アプリアップデートの再スケジュール用    -->
-        <receiver android:name=".widget.WidgetUpdater$OnBootCompleteOrPackageReplaced">
+        <receiver android:name=".widget.WidgetUpdater$OnBootCompleteOrPackageReplaced"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
@@ -94,7 +99,8 @@
             </intent-filter>
         </receiver>
         <!--    スマホ再起動時 / アプリアップデートの再スケジュール用    -->
-        <receiver android:name=".work.ScheduleNotifier$OnBootCompleteOrPackageReplaced">
+        <receiver android:name=".work.ScheduleNotifier$OnBootCompleteOrPackageReplaced"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />

--- a/app/src/main/java/net/twinte/android/widget/Utils.kt
+++ b/app/src/main/java/net/twinte/android/widget/Utils.kt
@@ -149,7 +149,7 @@ fun AppWidgetProvider.errorView(context: Context, widgetId: Int, title: String, 
                     action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
                     putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, intArrayOf(widgetId))
                 },
-                0
+                PendingIntent.FLAG_IMMUTABLE
             )
         )
     }

--- a/app/src/main/java/net/twinte/android/widget/V3LargeWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3LargeWidgetProvider.kt
@@ -83,7 +83,7 @@ class V3LargeWidgetProvider : AppWidgetProvider() {
                     R.id.course_listView,
                     PendingIntent.getActivity(context, 0, Intent(context, MainActivity::class.java).apply {
                         flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                    }, PendingIntent.FLAG_UPDATE_CURRENT)
+                    }, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
 
                 appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.course_listView)

--- a/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
@@ -82,7 +82,7 @@ class V3MediumWidgetProvider : AppWidgetProvider() {
                     R.id.course_listView,
                     PendingIntent.getActivity(context, 0, Intent(context, MainActivity::class.java).apply {
                         flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                    }, PendingIntent.FLAG_UPDATE_CURRENT)
+                    }, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
 
                 appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetId, R.id.course_listView)

--- a/app/src/main/java/net/twinte/android/widget/V3SmallWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3SmallWidgetProvider.kt
@@ -70,7 +70,7 @@ class V3SmallWidgetProvider : AppWidgetProvider() {
                         nextCourse?.id?.let {
                             putExtra("REGISTERED_COURSE_ID", it)
                         }
-                    }, PendingIntent.FLAG_UPDATE_CURRENT)
+                    }, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
                 )
 
                 if (TWINTE_DEBUG)

--- a/app/src/main/java/net/twinte/android/widget/WidgetUpdater.kt
+++ b/app/src/main/java/net/twinte/android/widget/WidgetUpdater.kt
@@ -52,7 +52,7 @@ object WidgetUpdater {
                 context,
                 "${time.hour}${time.minute}".toInt(),
                 intent,
-                PendingIntent.FLAG_CANCEL_CURRENT
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
             )
         }
 

--- a/app/src/main/java/net/twinte/android/work/ScheduleNotifier.kt
+++ b/app/src/main/java/net/twinte/android/work/ScheduleNotifier.kt
@@ -78,7 +78,12 @@ class ScheduleNotifier : BroadcastReceiver() {
         private fun alarmIntent(context: Context, requestCode: Int) =
             Intent(context, ScheduleNotifier::class.java).let { intent ->
                 intent.action = "net.twinte.android.action.ScheduleNotifier"
-                PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_CANCEL_CURRENT)
+                PendingIntent.getBroadcast(
+                    context,
+                    requestCode,
+                    intent,
+                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
             }
     }
 
@@ -129,14 +134,14 @@ class ScheduleNotifier : BroadcastReceiver() {
                 PendingIntent.getActivity(
                     context,
                     0,
-                    Intent(context, MainActivity::class.java), 0
+                    Intent(context, MainActivity::class.java), PendingIntent.FLAG_IMMUTABLE
                 )
             ).addAction(
                 R.drawable.ic_icon, "通知設定",
                 PendingIntent.getActivity(
                     context,
                     0,
-                    Intent(context, SettingsActivity::class.java), 0
+                    Intent(context, SettingsActivity::class.java), PendingIntent.FLAG_IMMUTABLE
                 )
             ).setContentTitle(title)
             .setContentText(text)

--- a/app/src/main/java/net/twinte/android/work/UpdateScheduleWorker.kt
+++ b/app/src/main/java/net/twinte/android/work/UpdateScheduleWorker.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.work.*
+import androidx.work.WorkRequest.Companion.MIN_BACKOFF_MILLIS
 import net.twinte.android.MainActivity
 import net.twinte.android.R
 import net.twinte.android.TWINTE_DEBUG
@@ -44,7 +45,7 @@ class UpdateScheduleWorker(appContext: Context, workerParams: WorkerParameters) 
                 .setInitialDelay(timeDiff, TimeUnit.MILLISECONDS)
                 .setBackoffCriteria(
                     BackoffPolicy.LINEAR,
-                    OneTimeWorkRequest.MIN_BACKOFF_MILLIS,
+                    MIN_BACKOFF_MILLIS,
                     TimeUnit.MILLISECONDS
                 )
                 .addTag(TAG).build()
@@ -81,7 +82,7 @@ class UpdateScheduleWorker(appContext: Context, workerParams: WorkerParameters) 
                 PendingIntent.getActivity(
                     context,
                     1,
-                    Intent(context, MainActivity::class.java), 0
+                    Intent(context, MainActivity::class.java), PendingIntent.FLAG_IMMUTABLE
                 )
             ).setContentTitle("[Debug]APIアクセス終了")
             .setContentText(msg)

--- a/app/src/main/res/layout/widget_v3_error.xml
+++ b/app/src/main/res/layout/widget_v3_error.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="16dp"
     android:background="@drawable/widget_rounded_bg"
     android:layout_width="match_parent"
@@ -21,8 +22,8 @@
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:tint="@color/widget_text_main"
-                android:src="@drawable/ic_error" />
+                android:src="@drawable/ic_error"
+                app:tint="@color/widget_text_main" />
 
             <TextView
                 android:id="@+id/error_title_textView"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
     val kotlinVersion by extra("1.6.21")
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath ("com.android.tools.build:gradle:8.0.0")
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    val kotlinVersion by extra("1.4.31")
+    val kotlinVersion by extra("1.6.21")
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath ("com.android.tools.build:gradle:4.1.1")
+        classpath ("com.android.tools.build:gradle:8.0.0")
         classpath ("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-        classpath ("com.google.android.gms:oss-licenses-plugin:0.10.3")
+        classpath ("com.google.android.gms:oss-licenses-plugin:0.10.4")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Apr 12 16:51:02 JST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# 概要

closes #24 

AGP および関連する依存関係の更新を実施し、twinte-android の開発をするための準備を完了します。

## 具体的な変更

- AGP を 8.0.0 にアップデート https://github.com/twin-te/twinte-android/commit/e7240a7985ed20b4a3e874cdee1ad746baa80df9
- `jcenter()` はすでに非推奨なため `mavenCentral()` に変更 https://github.com/twin-te/twinte-android/commit/41c533095fabebd73ac778864155937df7ded671
- AGP の更新により、`android:exported="true"` を明示的に指定する必要が生じたためそのようにした https://github.com/twin-te/twinte-android/commit/e4f2c057b772e018b83221ee3371137a53d18532
- AGP の更新により、`{compile,target}SdkVersion` に 31 以上を指定する必要が生じたためそのようにした https://github.com/twin-te/twinte-android/commit/bea95e61fa3ac718e586117d7715f70c515d7fcf
- AGP の更新により、`PendingIntent.FLAG_IMMUTABLE` を明示的に指定する必要が生じたが、依存パッケージが古くそうなっていないものがあったので更新した https://github.com/twin-te/twinte-android/commit/ed2453ecb4bab024aebb0882368426c443e37483
-  AGP の更新により、`PendingIntent.FLAG_IMMUTABLE` を明示的に指定する必要が生じたので twinte-android 側の関連箇所を修正 https://github.com/twin-te/twinte-android/commit/fc1601842d5d0a627324d08a2ce02577e605c4cc
- AGP の更新により、`./gradlew lint` が失敗するようになったのでその指摘箇所を修正 https://github.com/twin-te/twinte-android/pull/25/commits/d68fcc02f9558dedab0d59cf5ccea7221f267595
- AGP の更新とともに更新すべきだったファイルの git add が抜けていたので差分を追加 https://github.com/twin-te/twinte-android/pull/25/commits/d8e2faf5a5d09a5809d7068576ade23f7b61a15a

## 動作確認

- Google アカウントでログインできること
- それぞれのウィジェットが動作すること

@SIY1121 レビューお願いします。