### PR TITLE
Automatically build and lint with GitHub Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: '17'
+        cache: 'gradle'
+    - name: Lint
+      run: ./gradlew lint
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: '17'
+        cache: 'gradle'
+    - name: Run tests
+      run: ./gradlew testDebug --continue
+  assemble:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: '17'
+          cache: 'gradle'
+      - name: Build APK
+        run: ./gradlew assemble


### PR DESCRIPTION
# 概要

closes #26 

master と develop ブランチへの PR およびそれらのブランチへ push されたコミットについて自動的に以下のタスクをそれぞれ実行し、成功するかどうか確かめるようにします。

- `lint`（XML 関連の記法の自動的な検証）
- `testDebug`（単体テストの自動実行。今は `ExampleUnitTest` のみしかない）
- `assemble`（APK のビルド）