### PR TITLE
Add unit tests for DataStores

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,12 @@ dependencies {
     implementation("androidx.hilt:hilt-work:1.0.0")
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1")
+
+    // Mocking interfaces for testing
+    testImplementation("io.mockk:mockk:1.13.3")
+
+    // Running test with suspend functions
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.0")
 }
 
 kapt {

--- a/app/src/main/java/net/twinte/android/MainActivity.kt
+++ b/app/src/main/java/net/twinte/android/MainActivity.kt
@@ -25,10 +25,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import net.twinte.android.datastore.schedule.ScheduleDataStore
+import net.twinte.android.datastore.schedulenotification.ScheduleNotificationDataStore
+import net.twinte.android.datastore.user.UserDataStore
 import net.twinte.android.network.serversettings.ServerSettings
-import net.twinte.android.repository.schedule.ScheduleRepository
-import net.twinte.android.repository.schedulenotification.ScheduleNotificationRepository
-import net.twinte.android.repository.user.UserRepository
 import net.twinte.android.widget.WidgetUpdater
 import net.twinte.android.work.UpdateScheduleWorker
 import javax.inject.Inject
@@ -40,13 +40,13 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
     var filePathCallback: ValueCallback<Array<Uri>>? = null
 
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
     @Inject
-    lateinit var userRepository: UserRepository
+    lateinit var userDataStore: UserDataStore
 
     @Inject
-    lateinit var scheduleNotificationRepository: ScheduleNotificationRepository
+    lateinit var scheduleNotificationDataStore: ScheduleNotificationDataStore
 
     @Inject
     lateinit var cookieManager: CookieManager
@@ -63,10 +63,10 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
         setContentView(R.layout.activity_main)
 
         UpdateScheduleWorker.scheduleNextUpdate(workManager)
-        scheduleNotificationRepository.schedule()
+        scheduleNotificationDataStore.schedule()
         GlobalScope.launch {
             try {
-                scheduleRepository.update()
+                scheduleDataStore.update()
             } catch (e: NotLoggedInException) {
                 // 未ログイン時は失敗するが何もしない
             } catch (e: Exception) {
@@ -183,7 +183,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
                 val account = GoogleSignIn.getSignedInAccountFromIntent(data).result
                 GlobalScope.launch {
                     account?.idToken?.let {
-                        userRepository.validateGoogleIdToken(it)
+                        userDataStore.validateGoogleIdToken(it)
                     }
                     withContext(Dispatchers.Main) {
                         main_webview.loadUrl(twinteUrlBuilder(serverSettings).buildUrl())
@@ -206,7 +206,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
         cookieManager.flush()
         GlobalScope.launch {
             try {
-                scheduleRepository.update()
+                scheduleDataStore.update()
             } catch (e: NotLoggedInException) {
                 // 未ログイン時は失敗するが何もしない
             }

--- a/app/src/main/java/net/twinte/android/MainApplicationModule.kt
+++ b/app/src/main/java/net/twinte/android/MainApplicationModule.kt
@@ -39,8 +39,6 @@ interface MainApplicationModule {
     ): ScheduleNotificationDataStore
 
     companion object {
-
-        @Suppress("ForbiddenComment")
         // TODO: リリース版でのみ ProductionServerSettings を inject するように変更する（マルチモジュール化が必要）
         @Provides
         fun provideServerSettings(): ServerSettings = ProductionServerSettings()

--- a/app/src/main/java/net/twinte/android/MainApplicationModule.kt
+++ b/app/src/main/java/net/twinte/android/MainApplicationModule.kt
@@ -9,34 +9,34 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import net.twinte.android.datastore.schedule.ScheduleDataStore
+import net.twinte.android.datastore.schedule.SharedPreferencesScheduleDataStore
+import net.twinte.android.datastore.schedulenotification.ScheduleNotificationDataStore
+import net.twinte.android.datastore.schedulenotification.SharedPreferencesScheduleNotificationDataStore
+import net.twinte.android.datastore.user.TwinteBackendUserDataStore
+import net.twinte.android.datastore.user.UserDataStore
 import net.twinte.android.network.TwinteBackendHttpClient
 import net.twinte.android.network.TwinteBackendHttpClientImpl
 import net.twinte.android.network.serversettings.ProductionServerSettings
 import net.twinte.android.network.serversettings.ServerSettings
-import net.twinte.android.repository.schedule.ScheduleRepository
-import net.twinte.android.repository.schedule.SharedPreferencesScheduleRepository
-import net.twinte.android.repository.schedulenotification.ScheduleNotificationRepository
-import net.twinte.android.repository.schedulenotification.SharedPreferencesScheduleNotificationRepository
-import net.twinte.android.repository.user.TwinteBackendUserRepository
-import net.twinte.android.repository.user.UserRepository
 
 @Module
 @InstallIn(SingletonComponent::class)
 interface MainApplicationModule {
     @Binds
-    fun bindScheduleRepository(
-        scheduleRepository: SharedPreferencesScheduleRepository,
-    ): ScheduleRepository
+    fun bindScheduleDataStore(
+        scheduleDataStore: SharedPreferencesScheduleDataStore,
+    ): ScheduleDataStore
 
     @Binds
-    fun bindUserRepository(
-        userRepository: TwinteBackendUserRepository,
-    ): UserRepository
+    fun bindUserDataStore(
+        userDataStore: TwinteBackendUserDataStore,
+    ): UserDataStore
 
     @Binds
-    fun bindScheduleNotificationRepository(
-        scheduleNotificationRepository: SharedPreferencesScheduleNotificationRepository,
-    ): ScheduleNotificationRepository
+    fun bindScheduleNotificationDataStore(
+        scheduleNotificationDataStore: SharedPreferencesScheduleNotificationDataStore,
+    ): ScheduleNotificationDataStore
 
     companion object {
 

--- a/app/src/main/java/net/twinte/android/datastore/schedule/ScheduleDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/schedule/ScheduleDataStore.kt
@@ -1,10 +1,10 @@
-package net.twinte.android.repository.schedule
+package net.twinte.android.datastore.schedule
 
 import net.twinte.android.model.Timetable
 import java.util.Calendar
 import java.util.Date
 
-interface ScheduleRepository {
+interface ScheduleDataStore {
     suspend fun update(
         calendar: Array<Date> = arrayOf(
             Calendar.getInstance().time,

--- a/app/src/main/java/net/twinte/android/datastore/schedule/SharedPreferencesScheduleDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/schedule/SharedPreferencesScheduleDataStore.kt
@@ -1,7 +1,6 @@
 package net.twinte.android.datastore.schedule
 
 import android.content.Context
-import android.util.Log
 import com.google.gson.Gson
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -37,7 +36,8 @@ class SharedPreferencesScheduleDataStore @Inject constructor(
                     }
                 }
                 putString(d, res.body?.string())
-                Log.d(TAG, "schedule updated $d $res")
+                // TODO: replace `android.util.Log` with Timber
+                // Log.d(TAG, "schedule updated $d $res")
             }
             commit()
         }
@@ -48,9 +48,5 @@ class SharedPreferencesScheduleDataStore @Inject constructor(
         if (!pref.contains(d)) update(arrayOf(date))
 
         gson.fromJson(pref.getString(d, null), Timetable::class.java)
-    }
-
-    companion object {
-        private val TAG = SharedPreferencesScheduleDataStore::class.java.simpleName
     }
 }

--- a/app/src/main/java/net/twinte/android/datastore/schedule/SharedPreferencesScheduleDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/schedule/SharedPreferencesScheduleDataStore.kt
@@ -1,4 +1,4 @@
-package net.twinte.android.repository.schedule
+package net.twinte.android.datastore.schedule
 
 import android.content.Context
 import android.util.Log
@@ -15,10 +15,10 @@ import java.util.Date
 import java.util.Locale
 import javax.inject.Inject
 
-class SharedPreferencesScheduleRepository @Inject constructor(
+class SharedPreferencesScheduleDataStore @Inject constructor(
     @ApplicationContext context: Context,
     private val twinteBackendHttpClient: TwinteBackendHttpClient,
-) : ScheduleRepository {
+) : ScheduleDataStore {
     private val pref = context.getSharedPreferences("schedule_cache", Context.MODE_PRIVATE)
     private val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.JAPAN)
     private val gson = Gson()
@@ -37,7 +37,7 @@ class SharedPreferencesScheduleRepository @Inject constructor(
                     }
                 }
                 putString(d, res.body?.string())
-                Log.d("ScheduleRepository", "schedule updated $d $res")
+                Log.d(TAG, "schedule updated $d $res")
             }
             commit()
         }
@@ -48,5 +48,9 @@ class SharedPreferencesScheduleRepository @Inject constructor(
         if (!pref.contains(d)) update(arrayOf(date))
 
         gson.fromJson(pref.getString(d, null), Timetable::class.java)
+    }
+
+    companion object {
+        private val TAG = SharedPreferencesScheduleDataStore::class.java.simpleName
     }
 }

--- a/app/src/main/java/net/twinte/android/datastore/schedulenotification/ScheduleNotificationDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/schedulenotification/ScheduleNotificationDataStore.kt
@@ -1,0 +1,5 @@
+package net.twinte.android.datastore.schedulenotification
+
+interface ScheduleNotificationDataStore {
+    fun schedule()
+}

--- a/app/src/main/java/net/twinte/android/datastore/schedulenotification/SharedPreferencesScheduleNotificationDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/schedulenotification/SharedPreferencesScheduleNotificationDataStore.kt
@@ -1,4 +1,4 @@
-package net.twinte.android.repository.schedulenotification
+package net.twinte.android.datastore.schedulenotification
 
 import android.app.AlarmManager
 import android.app.PendingIntent
@@ -12,9 +12,9 @@ import net.twinte.android.work.ScheduleNotifier
 import java.util.Calendar
 import javax.inject.Inject
 
-class SharedPreferencesScheduleNotificationRepository @Inject constructor(
+class SharedPreferencesScheduleNotificationDataStore @Inject constructor(
     @ApplicationContext private val context: Context,
-) : ScheduleNotificationRepository {
+) : ScheduleNotificationDataStore {
     private val preferenceChangeListener by lazy {
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key != "enable_schedule_notification" && key != "notification_timing") return@OnSharedPreferenceChangeListener

--- a/app/src/main/java/net/twinte/android/datastore/user/TwinteBackendUserDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/user/TwinteBackendUserDataStore.kt
@@ -1,4 +1,4 @@
-package net.twinte.android.repository.user
+package net.twinte.android.datastore.user
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -6,9 +6,9 @@ import net.twinte.android.network.TwinteBackendHttpClient
 import net.twinte.android.network.params
 import javax.inject.Inject
 
-class TwinteBackendUserRepository @Inject constructor(
+class TwinteBackendUserDataStore @Inject constructor(
     private val twinteBackendHttpClient: TwinteBackendHttpClient,
-) : UserRepository {
+) : UserDataStore {
     override suspend fun validateGoogleIdToken(idToken: String): Boolean = withContext(Dispatchers.IO) {
         val res = twinteBackendHttpClient.get(
             "/auth/v3/google/idToken",

--- a/app/src/main/java/net/twinte/android/datastore/user/UserDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/user/UserDataStore.kt
@@ -1,0 +1,5 @@
+package net.twinte.android.datastore.user
+
+interface UserDataStore {
+    suspend fun validateGoogleIdToken(idToken: String): Boolean
+}

--- a/app/src/main/java/net/twinte/android/repository/schedulenotification/ScheduleNotificationRepository.kt
+++ b/app/src/main/java/net/twinte/android/repository/schedulenotification/ScheduleNotificationRepository.kt
@@ -1,5 +1,0 @@
-package net.twinte.android.repository.schedulenotification
-
-interface ScheduleNotificationRepository {
-    fun schedule()
-}

--- a/app/src/main/java/net/twinte/android/repository/user/UserRepository.kt
+++ b/app/src/main/java/net/twinte/android/repository/user/UserRepository.kt
@@ -1,5 +1,0 @@
-package net.twinte.android.repository.user
-
-interface UserRepository {
-    suspend fun validateGoogleIdToken(idToken: String): Boolean
-}

--- a/app/src/main/java/net/twinte/android/widget/V3LargeWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3LargeWidgetProvider.kt
@@ -14,8 +14,8 @@ import net.twinte.android.MainActivity
 import net.twinte.android.NotLoggedInException
 import net.twinte.android.R
 import net.twinte.android.TWINTE_DEBUG
+import net.twinte.android.datastore.schedule.ScheduleDataStore
 import net.twinte.android.model.Timetable
-import net.twinte.android.repository.schedule.ScheduleRepository
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -27,7 +27,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class V3LargeWidgetProvider @Inject constructor() : AppWidgetProvider() {
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
     /**
      * 設置されたLargeウィジットの数が 0 -> 1 になると呼び出される
@@ -52,10 +52,10 @@ class V3LargeWidgetProvider @Inject constructor() : AppWidgetProvider() {
         appWidgetIds: IntArray,
     ) = runBlocking {
         Log.d("V3LargeWidgetProvider", "OnUpdate received")
-        val (current, period) = WidgetUpdater.getShouldShowCurrentDate()
+        val (current) = WidgetUpdater.getShouldShowCurrentDate()
 
         try {
-            val schedule = scheduleRepository.getSchedule(current.time)
+            val schedule = scheduleDataStore.getSchedule(current.time)
 
             appWidgetIds.forEach { appWidgetId ->
                 val views = RemoteViews(
@@ -126,14 +126,14 @@ class V3LargeWidgetProvider @Inject constructor() : AppWidgetProvider() {
 @AndroidEntryPoint
 class V3LargeWidgetRemoteViewService @Inject constructor() : RemoteViewsService() {
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
-    override fun onGetViewFactory(intent: Intent?) = Factory(applicationContext, intent, scheduleRepository)
+    override fun onGetViewFactory(intent: Intent?) = Factory(applicationContext, intent, scheduleDataStore)
 
     class Factory(
         val context: Context,
         val intent: Intent?,
-        private val scheduleRepository: ScheduleRepository,
+        private val scheduleDataStore: ScheduleDataStore,
     ) : RemoteViewsFactory {
         var schedule: Timetable? = null
 
@@ -142,7 +142,7 @@ class V3LargeWidgetRemoteViewService @Inject constructor() : RemoteViewsService(
         override fun onDataSetChanged() = runBlocking {
             Log.d("LargeFactory", "onDataSetChanged")
             val (current, _) = WidgetUpdater.getShouldShowCurrentDate()
-            schedule = scheduleRepository.getSchedule(current.time)
+            schedule = scheduleDataStore.getSchedule(current.time)
         }
 
         override fun onDestroy() {}

--- a/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
@@ -14,8 +14,8 @@ import net.twinte.android.MainActivity
 import net.twinte.android.NotLoggedInException
 import net.twinte.android.R
 import net.twinte.android.TWINTE_DEBUG
+import net.twinte.android.datastore.schedule.ScheduleDataStore
 import net.twinte.android.model.Timetable
-import net.twinte.android.repository.schedule.ScheduleRepository
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -27,7 +27,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class V3MediumWidgetProvider @Inject constructor() : AppWidgetProvider() {
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
     /**
      * 設置されたMediumウィジットの数が 0 -> 1 になると呼び出される
@@ -52,9 +52,9 @@ class V3MediumWidgetProvider @Inject constructor() : AppWidgetProvider() {
         appWidgetIds: IntArray,
     ) = runBlocking {
         Log.d("V3MediumWidgetProvider", "OnUpdate received")
-        val (current, period) = WidgetUpdater.getShouldShowCurrentDate()
+        val (current) = WidgetUpdater.getShouldShowCurrentDate()
         try {
-            val schedule = scheduleRepository.getSchedule(current.time)
+            val schedule = scheduleDataStore.getSchedule(current.time)
 
             appWidgetIds.forEach { appWidgetId ->
                 val views = RemoteViews(
@@ -124,14 +124,14 @@ class V3MediumWidgetProvider @Inject constructor() : AppWidgetProvider() {
  */
 class V3MediumWidgetRemoteViewService @Inject constructor() : RemoteViewsService() {
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
-    override fun onGetViewFactory(intent: Intent?) = Factory(applicationContext, intent, scheduleRepository)
+    override fun onGetViewFactory(intent: Intent?) = Factory(applicationContext, intent, scheduleDataStore)
 
     class Factory(
         val context: Context,
         val intent: Intent?,
-        val scheduleRepository: ScheduleRepository,
+        val scheduleDataStore: ScheduleDataStore,
     ) : RemoteViewsFactory {
         var schedule: Timetable? = null
 
@@ -140,7 +140,7 @@ class V3MediumWidgetRemoteViewService @Inject constructor() : RemoteViewsService
         override fun onDataSetChanged() = runBlocking {
             Log.d("MediumFactory", "onDataSetChanged")
             val (current, _) = WidgetUpdater.getShouldShowCurrentDate()
-            schedule = scheduleRepository.getSchedule(current.time)
+            schedule = scheduleDataStore.getSchedule(current.time)
         }
 
         override fun onDestroy() {}

--- a/app/src/main/java/net/twinte/android/widget/V3SmallWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3SmallWidgetProvider.kt
@@ -13,7 +13,7 @@ import net.twinte.android.MainActivity
 import net.twinte.android.NotLoggedInException
 import net.twinte.android.R
 import net.twinte.android.TWINTE_DEBUG
-import net.twinte.android.repository.schedule.ScheduleRepository
+import net.twinte.android.datastore.schedule.ScheduleDataStore
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -25,7 +25,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class V3SmallWidgetProvider @Inject constructor() : AppWidgetProvider() {
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
     /**
      * 設置されたSmallウィジットの数が 0 -> 1 になると呼び出される
@@ -53,7 +53,7 @@ class V3SmallWidgetProvider @Inject constructor() : AppWidgetProvider() {
         val (current, period) = WidgetUpdater.getShouldShowCurrentDate()
 
         try {
-            val schedule = scheduleRepository.getSchedule(current.time)
+            val schedule = scheduleDataStore.getSchedule(current.time)
 
             appWidgetIds.forEach { appWidgetId ->
                 val views = RemoteViews(

--- a/app/src/main/java/net/twinte/android/work/ScheduleNotifier.kt
+++ b/app/src/main/java/net/twinte/android/work/ScheduleNotifier.kt
@@ -14,9 +14,9 @@ import net.twinte.android.MainActivity
 import net.twinte.android.R
 import net.twinte.android.SettingsActivity
 import net.twinte.android.TWINTE_DEBUG
+import net.twinte.android.datastore.schedule.ScheduleDataStore
+import net.twinte.android.datastore.schedulenotification.ScheduleNotificationDataStore
 import net.twinte.android.model.Day
-import net.twinte.android.repository.schedule.ScheduleRepository
-import net.twinte.android.repository.schedulenotification.ScheduleNotificationRepository
 import java.util.Calendar
 import javax.inject.Inject
 
@@ -26,7 +26,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ScheduleNotifier : BroadcastReceiver() {
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
     override fun onReceive(context: Context, intent: Intent?) = runBlocking {
         Log.d("ScheduleNotifier", "Received Broadcast")
@@ -35,7 +35,7 @@ class ScheduleNotifier : BroadcastReceiver() {
                 if (get(Calendar.HOUR_OF_DAY) > 18) add(Calendar.DATE, 1)
             }
 
-            val schedule = scheduleRepository.getSchedule(targetDate.time)
+            val schedule = scheduleDataStore.getSchedule(targetDate.time)
 
             val substitute = schedule.events.find { it.changeTo != null }?.changeTo
             if (substitute != null) {
@@ -98,11 +98,11 @@ class ScheduleNotifier : BroadcastReceiver() {
     @AndroidEntryPoint
     class OnBootCompleteOrPackageReplaced @Inject constructor() : BroadcastReceiver() {
         @Inject
-        lateinit var scheduleNotificationRepository: ScheduleNotificationRepository
+        lateinit var scheduleNotificationDataStore: ScheduleNotificationDataStore
 
         override fun onReceive(context: Context, intent: Intent?) {
             Log.d("ScheduleNotifier", "onReceived ${intent?.action}")
-            scheduleNotificationRepository.schedule()
+            scheduleNotificationDataStore.schedule()
         }
     }
 }

--- a/app/src/main/java/net/twinte/android/work/UpdateScheduleWorker.kt
+++ b/app/src/main/java/net/twinte/android/work/UpdateScheduleWorker.kt
@@ -21,7 +21,7 @@ import dagger.assisted.AssistedInject
 import net.twinte.android.MainActivity
 import net.twinte.android.R
 import net.twinte.android.TWINTE_DEBUG
-import net.twinte.android.repository.schedule.ScheduleRepository
+import net.twinte.android.datastore.schedule.ScheduleDataStore
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
@@ -37,7 +37,7 @@ class UpdateScheduleWorker @AssistedInject constructor(
 ) : CoroutineWorker(appContext, workerParams) {
 
     @Inject
-    lateinit var scheduleRepository: ScheduleRepository
+    lateinit var scheduleDataStore: ScheduleDataStore
 
     @Inject
     lateinit var workManager: WorkManager
@@ -78,7 +78,7 @@ class UpdateScheduleWorker @AssistedInject constructor(
     }
 
     override suspend fun doWork() = try {
-        scheduleRepository.update()
+        scheduleDataStore.update()
         scheduleNextUpdate(workManager)
         Log.d("UpdateScheduleWorker", "work success")
         if (TWINTE_DEBUG) {

--- a/app/src/test/java/net/twinte/android/datastore/schedule/SharedPreferencesScheduleDataStoreTest.kt
+++ b/app/src/test/java/net/twinte/android/datastore/schedule/SharedPreferencesScheduleDataStoreTest.kt
@@ -1,0 +1,40 @@
+package net.twinte.android.datastore.schedule
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import net.twinte.android.network.TwinteBackendHttpClient
+import okhttp3.Response
+import org.junit.Test
+import java.util.Calendar
+import java.util.Date
+
+class SharedPreferencesScheduleDataStoreTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun validTimetablePath() = runTest {
+        // given
+        val httpClient = mockk<TwinteBackendHttpClient>()
+        val datastore = SharedPreferencesScheduleDataStore(
+            mockk(relaxed = true),
+            httpClient,
+        )
+        val date = Date.from(
+            // month value is zero-based, hence indicating 6th month (June)
+            Calendar.getInstance().apply { set(2022, 5, 10) }.toInstant(),
+        )
+        val pathSlot = slot<String>()
+        coEvery { httpClient.get(capture(pathSlot), any()) } returns mockk<Response>(relaxed = true).also {
+            every { it.isSuccessful } returns true
+        }
+
+        // when
+        datastore.update(arrayOf(date))
+
+        // then
+        assert(pathSlot.captured == "/api/v3/timetable/2022-06-10")
+    }
+}

--- a/app/src/test/java/net/twinte/android/datastore/user/TwinteBackendUserDataStoreTest.kt
+++ b/app/src/test/java/net/twinte/android/datastore/user/TwinteBackendUserDataStoreTest.kt
@@ -1,0 +1,37 @@
+package net.twinte.android.datastore.user
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import net.twinte.android.network.QueryParameters
+import net.twinte.android.network.TwinteBackendHttpClient
+import okhttp3.Response
+import org.junit.Test
+
+class TwinteBackendUserDataStoreTest {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun validPath() = runTest {
+        // given
+        val httpClient = mockk<TwinteBackendHttpClient>()
+        val datastore = TwinteBackendUserDataStore(
+            httpClient,
+        )
+        val idToken = "idToken123"
+        val pathSlot = slot<String>()
+        val argumentSlot = slot<QueryParameters>()
+        coEvery { httpClient.get(capture(pathSlot), capture(argumentSlot)) } returns mockk<Response>().also {
+            every { it.isSuccessful } returns true
+        }
+
+        // when
+        datastore.validateGoogleIdToken(idToken)
+
+        // then
+        assert(pathSlot.captured == "/auth/v3/google/idToken")
+        assert(argumentSlot.captured.getValue("token") == idToken)
+    }
+}

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -46,6 +46,10 @@ style:
     active: true
     excludeImports:
       - 'kotlinx.android.synthetic.*'
+  ForbiddenComment:
+    values:
+      - 'FIXME:'
+      - 'STOPSHIP:'
 
 naming:
   active: true


### PR DESCRIPTION
# 概要

related: #31

今まで Repository として分割していたクラスは DataStore と名付けるのが適切だったため rename します。
また、テストを実施するために必要となるモック用ライブラリ（MockK）や suspend 関数を用いたテスト向けの関数 `runTest` を利用するための依存関係の追加をします。

加えて、まずは二つの DataStore が正しい path や params で API アクセスを試みているかを確認するためのテストを追加しています。