### PR TITLE
Introduce Gradle version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,12 +1,10 @@
-val kotlinVersion: String by project
-
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
-    id("kotlin-android-extensions")
-    id("com.google.android.gms.oss-licenses-plugin")
+    id(libs.plugins.android.application.get().pluginId)
+    id(libs.plugins.kotlin.android.core.get().pluginId)
+    id(libs.plugins.kotlin.android.extensions.get().pluginId)
+    id(libs.plugins.gms.oss.licenses.plugin.get().pluginId)
     kotlin("kapt")
-    id("com.google.dagger.hilt.android")
+    alias(libs.plugins.dagger.hilt.android.core)
 }
 
 android {
@@ -40,37 +38,37 @@ android {
 
 dependencies {
     implementation(fileTree("dir" to "libs", "include" to listOf("*.jar")))
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
-    implementation("androidx.core:core-ktx:1.6.0")
-    implementation("androidx.appcompat:appcompat:1.3.1")
-    implementation("androidx.work:work-runtime-ktx:2.8.1")
-    implementation("com.google.android.material:material:1.4.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.0")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")
-    implementation("androidx.navigation:navigation-ui-ktx:2.3.5")
-    implementation("androidx.preference:preference-ktx:1.1.1")
-    implementation("androidx.webkit:webkit:1.4.0")
-    implementation("com.google.android.gms:play-services-auth:19.2.0")
-    implementation("com.squareup.okhttp3:okhttp:4.9.0")
-    implementation("com.google.android.gms:play-services-oss-licenses:17.0.0")
-    implementation("com.google.code.gson:gson:2.8.6")
-    testImplementation("junit:junit:4.12")
-    androidTestImplementation("androidx.test.ext:junit:1.1.2")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.android.material)
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.navigation.fragment.ktx)
+    implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.androidx.preference.ktx)
+    implementation(libs.androidx.webkit)
+    implementation(libs.gms.play.services.auth)
+    implementation(libs.squareup.okhttp3)
+    implementation(libs.gms.play.services.oss.licenses)
+    implementation(libs.gson)
+    testImplementation(libs.junit.core)
+    androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.espresso.core)
 
     // Hilt
-    implementation("com.google.dagger:hilt-android:2.44")
-    kapt("com.google.dagger:hilt-android-compiler:2.44")
-    implementation("androidx.hilt:hilt-work:1.0.0")
+    implementation(libs.hilt.android.core)
+    kapt(libs.hilt.android.compiler)
+    implementation(libs.hilt.work)
 
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1")
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
 
     // Mocking interfaces for testing
-    testImplementation("io.mockk:mockk:1.13.3")
+    testImplementation(libs.mockk)
 
     // Running test with suspend functions
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.0")
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 kapt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,23 +5,22 @@ import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    val kotlinVersion by extra("1.6.21")
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath ("com.android.tools.build:gradle:8.0.0")
-        classpath ("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-        classpath ("com.google.android.gms:oss-licenses-plugin:0.10.4")
+        classpath (libs.android.tools.build.gradle)
+        classpath (libs.kotlin.gradle.plugin)
+        classpath (libs.gms.oss.licenses.plugin)
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("1.22.0")
-    id("com.google.dagger.hilt.android") version "2.44" apply false
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.dagger.hilt.android.core) apply false
 }
 // see https://detekt.dev/docs/introduction/reporting/#merging-reports
 val reportMerge by tasks.registering(ReportMergeTask::class) {
@@ -31,7 +30,7 @@ subprojects {
     apply(plugin = "io.gitlab.arturbosch.detekt")
 
     dependencies {
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.22.0")
+        detektPlugins(rootProject.project.libs.detekt.formatting)
     }
 
     detekt {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,47 @@
+[versions]
+kotlin = "1.6.21"
+detekt = "1.22.0"
+hilt = "2.44"
+agp = "8.0.0"
+gms-oss-licenses = "0.10.4"
+
+[libraries]
+android-tools-build-gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+gms-oss-licenses-plugin = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "gms-oss-licenses" }
+detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version = "1.5.0" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.6.0" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version = "1.3.1" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version = "2.8.1" }
+android-material = { group = "com.google.android.material", name = "material", version = "1.4.0" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.1.0" }
+androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version = "2.3.5" }
+androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version = "2.3.5" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version = "1.1.1" }
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version = "1.4.0" }
+gms-play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version = "19.2.0" }
+squareup-okhttp3 = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.9.0" }
+gms-play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version = "17.0.0" }
+gson = { group = "com.google.code.gson", name = "gson", version = "2.8.6" }
+
+junit-core = { group = "junit", name = "junit", version = "4.12" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version = "1.1.2" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version = "3.3.0" }
+
+hilt-android-core = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version = "1.0.0" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version = "2.5.1" }
+mockk = { group = "io.mockk", name = "mockk", version = "1.13.3" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.5.0" }
+
+[plugins]
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dagger-hilt-android-core = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android-core = { id = "kotlin-android", version.ref = "kotlin" }
+kotlin-android-extensions = { id = "kotlin-android-extensions", version.ref = "kotlin" }
+gms-oss-licenses-plugin = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "gms-oss-licenses" }


### PR DESCRIPTION
# 概要

related: #30

twinte-android 全体で利用する依存関係を単体のファイルで管理できるようにするため Gradle version catalog を導入します。