### PR TITLE
Fix injection of `ScheduleDataStore` to `V3MediumWidgetRemoteViewService`

### DIFF
--- a/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
@@ -122,6 +122,7 @@ class V3MediumWidgetProvider @Inject constructor() : AppWidgetProvider() {
 /**
  * ウィジット右側のリストを生成するサービス
  */
+@AndroidEntryPoint
 class V3MediumWidgetRemoteViewService @Inject constructor() : RemoteViewsService() {
     @Inject
     lateinit var scheduleDataStore: ScheduleDataStore


### PR DESCRIPTION
# 概要

#35 で DI を導入した際に `V3MediumWidgetRemoteViewService` に `AndroidEntryPoint` アノテーションを付与し忘れており、dependency injection が発生せず `scheduleDataStore` がいつまでも初期化されていないために例外が発生していたのを修正します。

<details>
<summary>エラーログ</summary>

```
FATAL EXCEPTION: main
Process: net.twinte.android, PID: 5384
java.lang.RuntimeException: Unable to bind to service net.twinte.android.widget.V3MediumWidgetRemoteViewService@5a7edc1 with Intent { cmp=net.twinte.android/.widget.V3MediumWidgetRemoteViewService (has extras) }: kotlin.UninitializedPropertyAccessException: lateinit property scheduleDataStore has not been initialized
	at android.app.ActivityThread.handleBindService(ActivityThread.java:4530)
	at android.app.ActivityThread.-$$Nest$mhandleBindService(Unknown Source:0)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2166)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7872)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
Caused by: kotlin.UninitializedPropertyAccessException: lateinit property scheduleDataStore has not been initialized
	at net.twinte.android.widget.V3MediumWidgetRemoteViewService.getScheduleDataStore(V3MediumWidgetProvider.kt:127)
	at net.twinte.android.widget.V3MediumWidgetRemoteViewService.onGetViewFactory(V3MediumWidgetProvider.kt:129)
	at net.twinte.android.widget.V3MediumWidgetRemoteViewService.onGetViewFactory(V3MediumWidgetProvider.kt:125)
	at android.widget.RemoteViewsService.onBind(RemoteViewsService.java:241)
	at android.app.ActivityThread.handleBindService(ActivityThread.java:4515)
	at android.app.ActivityThread.-$$Nest$mhandleBindService(Unknown Source:0) 
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2166) 
	at android.os.Handler.dispatchMessage(Handler.java:106) 
	at android.os.Looper.loopOnce(Looper.java:201) 
	at android.os.Looper.loop(Looper.java:288) 
	at android.app.ActivityThread.main(ActivityThread.java:7872) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936) 
```
</details>