### PR TITLE
Migrate from Kotlin synthetics to Jetpack view binding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id(libs.plugins.android.application.get().pluginId)
     id(libs.plugins.kotlin.android.core.get().pluginId)
-    id(libs.plugins.kotlin.android.extensions.get().pluginId)
     id(libs.plugins.gms.oss.licenses.plugin.get().pluginId)
     kotlin("kapt")
     alias(libs.plugins.dagger.hilt.android.core)
@@ -18,6 +17,10 @@ android {
         versionName = "2.0.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 
     buildTypes {

--- a/app/src/main/java/net/twinte/android/MainActivity.kt
+++ b/app/src/main/java/net/twinte/android/MainActivity.kt
@@ -20,11 +20,11 @@ import androidx.work.WorkManager
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import net.twinte.android.databinding.ActivityMainBinding
 import net.twinte.android.datastore.schedule.ScheduleDataStore
 import net.twinte.android.datastore.schedulenotification.ScheduleNotificationDataStore
 import net.twinte.android.datastore.user.UserDataStore
@@ -57,10 +57,13 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
     @Inject
     lateinit var workManager: WorkManager
 
+    lateinit var binding: ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
         setTheme(R.style.AppTheme_Main)
-        setContentView(R.layout.activity_main)
+        setContentView(binding.root)
 
         UpdateScheduleWorker.scheduleNextUpdate(workManager)
         scheduleNotificationDataStore.schedule()
@@ -80,13 +83,13 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
             WebView.setWebContentsDebuggingEnabled(true)
         }
 
-        main_webview.setup()
+        binding.mainWebview.setup()
 
         val url = intent.getStringExtra("REGISTERED_COURSE_ID")
             ?.let { twinteUrlBuilder(serverSettings).appendPath("course").appendPath(it).buildUrl() }
             ?: twinteUrlBuilder(serverSettings).buildUrl()
 
-        main_webview.loadUrl(url)
+        binding.mainWebview.loadUrl(url)
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -168,7 +171,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
 
                 @JavascriptInterface
                 fun share(body: String) {
-                    main_webview.shareScreen(body)
+                    binding.mainWebview.shareScreen(body)
                 }
             },
             "android",
@@ -186,7 +189,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
                         userDataStore.validateGoogleIdToken(it)
                     }
                     withContext(Dispatchers.Main) {
-                        main_webview.loadUrl(twinteUrlBuilder(serverSettings).buildUrl())
+                        binding.mainWebview.loadUrl(twinteUrlBuilder(serverSettings).buildUrl())
                     }
                 }
             }
@@ -218,7 +221,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
         super.onNewIntent(intent)
         intent.getStringExtra("REGISTERED_COURSE_ID")
             ?.let {
-                main_webview.loadUrl(twinteUrlBuilder(serverSettings).appendPath("course").appendPath(it).buildUrl())
+                binding.mainWebview.loadUrl(twinteUrlBuilder(serverSettings).appendPath("course").appendPath(it).buildUrl())
             }
     }
 
@@ -230,8 +233,8 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
     }
 
     override fun onBackPressed() {
-        if (main_webview.canGoBack()) {
-            main_webview.goBack()
+        if (binding.mainWebview.canGoBack()) {
+            binding.mainWebview.goBack()
         } else {
             super.onBackPressed()
         }
@@ -239,7 +242,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
 
     // SubWebViewでMainWebViewに読み込ませたくなった時に呼び出される
     override fun subWebViewCallback(url: String) {
-        main_webview.loadUrl(url)
+        binding.mainWebview.loadUrl(url)
     }
 
     companion object {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -44,8 +44,6 @@ style:
     active: false
   WildcardImport:
     active: true
-    excludeImports:
-      - 'kotlinx.android.synthetic.*'
   ForbiddenComment:
     values:
       - 'FIXME:'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,5 +43,4 @@ dagger-hilt-android-core = { id = "com.google.dagger.hilt.android", version.ref 
 
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android-core = { id = "kotlin-android", version.ref = "kotlin" }
-kotlin-android-extensions = { id = "kotlin-android-extensions", version.ref = "kotlin" }
 gms-oss-licenses-plugin = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "gms-oss-licenses" }


### PR DESCRIPTION
# 概要

Kotlin synthetics は deprecated になった後、現在では廃止されています。そのため、代替として利用できる Jetpack view binding への移行を実施します。

参考：https://developer.android.com/topic/libraries/view-binding/migration

## 動作確認

- 手元で `MainActivity` の操作ができること
  - 特にこの変更後、Twitter 等でログインするための画面を表示した際にページの読み込みが完了していない状態で Dismiss すると `_binding` が null になった後からページロード完了後のハンドラの呼び出しが発生して NullPointerException になる問題が新たに発生したが、それも解消した