### PR TITLE
[skip ci] Fix branch name from `main` to `master` in workflow file

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,11 +1,11 @@
 on:
   push:
     branches:
-      - main
+      - master
       - develop
   pull_request:
     branches:
-      - main
+      - master
       - develop
 
 jobs:


### PR DESCRIPTION
# 概要

今後 `master` ブランチで CI を走らせる必要があるが、workflow ファイルの中では `main` を指定してしまっているのを修正します。