### PR TITLE
Fix schedule importing feature from TWINS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId = "net.twinte.android"
-        minSdkVersion(23)
+        minSdk = 24
         targetSdkVersion (31)
         versionCode = 19
         versionName = "2.0.3"

--- a/app/src/main/java/net/twinte/android/MainActivity.kt
+++ b/app/src/main/java/net/twinte/android/MainActivity.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.twinte.android.databinding.ActivityMainBinding
+import net.twinte.android.datastore.resetcookiesforsamesite.ResetCookiesForSameSiteDataStore
 import net.twinte.android.datastore.schedule.ScheduleDataStore
 import net.twinte.android.datastore.schedulenotification.ScheduleNotificationDataStore
 import net.twinte.android.datastore.user.UserDataStore
@@ -47,6 +48,9 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
 
     @Inject
     lateinit var scheduleNotificationDataStore: ScheduleNotificationDataStore
+
+    @Inject
+    lateinit var resetCookiesForSameSiteDataStore: ResetCookiesForSameSiteDataStore
 
     @Inject
     lateinit var cookieManager: CookieManager
@@ -81,6 +85,13 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
 
         if (TWINTE_DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true)
+        }
+
+        // ref: https://github.com/twin-te/twinte-android/issues/44
+        // TODO: リリースしてから一年経過したら削除する（twinte_session は元々得られてから 1 年後に expire する設定になっている）
+        if (resetCookiesForSameSiteDataStore.shouldResetCookiesForSameSite) {
+            cookieManager.removeAllCookies {}
+            resetCookiesForSameSiteDataStore.shouldResetCookiesForSameSite = false
         }
 
         binding.mainWebview.setup()

--- a/app/src/main/java/net/twinte/android/MainApplicationModule.kt
+++ b/app/src/main/java/net/twinte/android/MainApplicationModule.kt
@@ -9,6 +9,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import net.twinte.android.datastore.resetcookiesforsamesite.ResetCookiesForSameSiteDataStore
+import net.twinte.android.datastore.resetcookiesforsamesite.ResetCookiesForSameSiteDataStoreImpl
 import net.twinte.android.datastore.schedule.ScheduleDataStore
 import net.twinte.android.datastore.schedule.SharedPreferencesScheduleDataStore
 import net.twinte.android.datastore.schedulenotification.ScheduleNotificationDataStore
@@ -37,6 +39,11 @@ interface MainApplicationModule {
     fun bindScheduleNotificationDataStore(
         scheduleNotificationDataStore: SharedPreferencesScheduleNotificationDataStore,
     ): ScheduleNotificationDataStore
+
+    @Binds
+    fun bindResetCookiesForSameSiteDataStore(
+        resetCookiesForSameSiteDataStoreImpl: ResetCookiesForSameSiteDataStoreImpl,
+    ): ResetCookiesForSameSiteDataStore
 
     companion object {
         // TODO: リリース版でのみ ProductionServerSettings を inject するように変更する（マルチモジュール化が必要）

--- a/app/src/main/java/net/twinte/android/datastore/resetcookiesforsamesite/ResetCookiesForSameSiteDataStore.kt
+++ b/app/src/main/java/net/twinte/android/datastore/resetcookiesforsamesite/ResetCookiesForSameSiteDataStore.kt
@@ -1,0 +1,11 @@
+package net.twinte.android.datastore.resetcookiesforsamesite
+
+/**
+ * ref: https://github.com/twin-te/twinte-android/issues/44
+ * SameSite 属性が付与されていない twinte_session Cookie があるとき、
+ * lTWINS からの時間割インポートに失敗するため、一度 WebView が利用できる Cookie を
+ * すべて削除し、再度 Twin:te の認証を行わせるために利用される DataStore
+ */
+interface ResetCookiesForSameSiteDataStore {
+    var shouldResetCookiesForSameSite: Boolean
+}

--- a/app/src/main/java/net/twinte/android/datastore/resetcookiesforsamesite/ResetCookiesForSameSiteDataStoreImpl.kt
+++ b/app/src/main/java/net/twinte/android/datastore/resetcookiesforsamesite/ResetCookiesForSameSiteDataStoreImpl.kt
@@ -1,0 +1,25 @@
+package net.twinte.android.datastore.resetcookiesforsamesite
+
+import android.content.Context
+import androidx.core.content.edit
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class ResetCookiesForSameSiteDataStoreImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ResetCookiesForSameSiteDataStore {
+    private val preferences = context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+
+    override var shouldResetCookiesForSameSite: Boolean
+        get() = preferences.getBoolean(KEY_RESET_COOKIES_FOR_SAMESITE, true)
+        set(value) {
+            preferences.edit {
+                putBoolean(KEY_RESET_COOKIES_FOR_SAMESITE, value)
+            }
+        }
+
+    companion object {
+        const val FILE_NAME = "reset_cookies_For_samesite"
+        private const val KEY_RESET_COOKIES_FOR_SAMESITE = "resetCookiesForSameSite"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version = "1.2.0" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version = "1.7.0" }
 gms-play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version = "20.5.0" }
-squareup-okhttp3 = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.11.0" }
+squareup-okhttp3 = { group = "com.squareup.okhttp3", name = "okhttp", version = "5.0.0-alpha.13" }
 gms-play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version = "17.0.1" }
 gson = { group = "com.google.code.gson", name = "gson", version = "2.10.1" }
 


### PR DESCRIPTION
# 概要

closes #44

TWINS から時間割をインポートできない問題を解消します。
原因や解消の方針は https://github.com/twin-te/twinte-android/issues/44#issuecomment-2062865228 に記述されています。

