### PR TITLE
Handle `java.lang.IOException` with network requests

### DIFF
--- a/app/src/main/java/net/twinte/android/widget/V3LargeWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3LargeWidgetProvider.kt
@@ -139,10 +139,11 @@ class V3LargeWidgetRemoteViewService @Inject constructor() : RemoteViewsService(
 
         override fun onCreate() {}
 
-        override fun onDataSetChanged() = runBlocking {
+        override fun onDataSetChanged(): Unit = runBlocking {
             Log.d("LargeFactory", "onDataSetChanged")
             val (current, _) = WidgetUpdater.getShouldShowCurrentDate()
-            schedule = scheduleDataStore.getSchedule(current.time)
+            kotlin.runCatching { scheduleDataStore.getSchedule(current.time) }
+                .onSuccess { schedule = it }
         }
 
         override fun onDestroy() {}

--- a/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
+++ b/app/src/main/java/net/twinte/android/widget/V3MediumWidgetProvider.kt
@@ -138,10 +138,11 @@ class V3MediumWidgetRemoteViewService @Inject constructor() : RemoteViewsService
 
         override fun onCreate() {}
 
-        override fun onDataSetChanged() = runBlocking {
+        override fun onDataSetChanged(): Unit = runBlocking {
             Log.d("MediumFactory", "onDataSetChanged")
             val (current, _) = WidgetUpdater.getShouldShowCurrentDate()
-            schedule = scheduleDataStore.getSchedule(current.time)
+            kotlin.runCatching { scheduleDataStore.getSchedule(current.time) }
+                .onSuccess { schedule = it }
         }
 
         override fun onDestroy() {}


### PR DESCRIPTION
# 概要

closes #45 

ネットワークリクエスト時に `java.lang.IOException` およびそのサブクラス関連の例外が発生してクラッシュしていた問題を修正します。