### PR TITLE
Bump up twinte-android to 2.1.1

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.21" />
+    <option name="version" value="1.9.23" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         minSdk = 24
         targetSdk = 34
         versionCode = 19
-        versionName = "2.0.3"
+        versionName = "2.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/net/twinte/android/MainActivity.kt
+++ b/app/src/main/java/net/twinte/android/MainActivity.kt
@@ -210,6 +210,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
         )
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
@@ -265,6 +266,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
             }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onAttachFragment(fragment: Fragment) {
         super.onAttachFragment(fragment)
         if (fragment is SubWebViewFragment) {
@@ -272,6 +274,7 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         if (binding.mainWebview.canGoBack()) {
             binding.mainWebview.goBack()

--- a/app/src/main/java/net/twinte/android/SubWebViewFragment.kt
+++ b/app/src/main/java/net/twinte/android/SubWebViewFragment.kt
@@ -122,6 +122,7 @@ class SubWebViewFragment : BottomSheetDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         object : BottomSheetDialog(requireContext(), theme) {
+            @Deprecated("Deprecated in Java")
             override fun onBackPressed() {
                 if (binding.subWebview.canGoBack()) {
                     // ダイアログで表示されているページから一つ前のページに戻れる場合、そこに戻る

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "1.8.21"
-detekt = "1.23.0"
-hilt = "2.46.1"
-agp = "8.0.2"
+kotlin = "1.9.23"
+detekt = "1.23.5"
+hilt = "2.51"
+agp = "8.3.2"
 gms-oss-licenses = "0.10.6"
 
 [libraries]
@@ -11,17 +11,17 @@ kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-p
 gms-oss-licenses-plugin = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "gms-oss-licenses" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
-kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version = "1.7.1" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.10.1" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version = "1.8.0" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.12.0" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version = "1.6.1" }
-androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version = "2.8.1" }
-android-material = { group = "com.google.android.material", name = "material", version = "1.9.0" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version = "2.9.0" }
+android-material = { group = "com.google.android.material", name = "material", version = "1.11.0" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.1.4" }
-androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version = "2.6.0" }
-androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version = "2.6.0" }
-androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version = "1.2.0" }
-androidx-webkit = { group = "androidx.webkit", name = "webkit", version = "1.7.0" }
-gms-play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version = "20.5.0" }
+androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version = "2.7.7" }
+androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version = "2.7.7" }
+androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version = "1.2.1" }
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version = "1.10.0" }
+gms-play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version = "21.1.0" }
 squareup-okhttp3 = { group = "com.squareup.okhttp3", name = "okhttp", version = "5.0.0-alpha.13" }
 gms-play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version = "17.0.1" }
 gson = { group = "com.google.code.gson", name = "gson", version = "2.10.1" }
@@ -32,8 +32,8 @@ androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espres
 
 hilt-android-core = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
-hilt-work = { group = "androidx.hilt", name = "hilt-work", version = "1.0.0" }
-androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version = "2.6.1" }
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version = "1.2.0" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version = "2.7.0" }
 mockk = { group = "io.mockk", name = "mockk", version = "1.13.3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.7.1" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Apr 12 16:51:02 JST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# 概要

#44, #45 の問題を解決したバージョンをリリースするために twinte-android のバージョンを上げます。
また、依存関係のバージョンも上げます。

手元でウィジェットやメイン画面、通知設定画面、ログイン、TWINS からのインポートなどが問題なく動作することを確認しています。
#45 に関して、エミュレータで品質が低いネットワークを再現させてみたり、機内モードの状態であってもクラッシュしないことを確認しています。

#46、#48、#49、そしてこの PR の差分を含んだものを 2.1.1 としてリリースしたいです。
アップロード鍵関連の箇所で私の環境では App Bundle のアップロードができなかったため、リリース作業をお願いしてもよろしいでしょうか？ @SIY1121 