### PR TITLE
Bump up versionCode to 21

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         applicationId = "net.twinte.android"
         minSdk = 24
         targetSdk = 34
-        versionCode = 19
+        versionCode = 21
         versionName = "2.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
# 概要

#50 で versionName を 2.1.1 に更新しましたが、リリースの都合上 `versionCode` の値もまた上げる必要があったため 21 にします。
差分では 19 が前の値になっていますが、現在のリリースでは versionCode が 20 の APK が含まれていることから 21 に更新します。