### PR TITLE
Bump up twinte-android to 2.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "net.twinte.android"
         minSdk = 24
         targetSdk = 34
-        versionCode = 21
-        versionName = "2.1.1"
+        versionCode = 22
+        versionName = "2.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
# 概要

twinte-android のバージョンを 2.1.2 (22) に上げます。

## 2.1.1 からの変更点

- https://github.com/twin-te/twinte-android/issues/52 の修正