### PR TITLE
Stop forcing algorithmic darkening

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "net.twinte.android"
         minSdk = 24
         targetSdk = 34
-        versionCode = 22
-        versionName = "2.1.2"
+        versionCode = 23
+        versionName = "2.1.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/net/twinte/android/MainActivity.kt
+++ b/app/src/main/java/net/twinte/android/MainActivity.kt
@@ -19,9 +19,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
-import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewClientCompat
-import androidx.webkit.WebViewFeature
 import androidx.work.WorkManager
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -189,11 +187,6 @@ class MainActivity : AppCompatActivity(), SubWebViewFragment.Callback {
             }
         }
 
-        if (
-            WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)
-        ) {
-            WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, true)
-        }
         addJavascriptInterface(
             object {
                 @JavascriptInterface


### PR DESCRIPTION
# 概要

closes #55

algorithmic darkening による配色の変更をやめ、端末のダークモード設定ではなく Twin:te 側のダークモード設定にのみ依存して配色を変更するようにします。

## スクリーンショット

| 変更前 | 変更後 |
| - | - |
| <img src="https://github.com/twin-te/twinte-android/assets/30387586/8cea91b1-a6d7-4797-9189-70956dd2000c" width="250"> | <img src="https://github.com/twin-te/twinte-android/assets/30387586/178f5464-6092-44ac-8fe3-c63a82d9a269" width="250"> |