### PR TITLE
Migrate to KSP from Kapt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id(libs.plugins.android.application.get().pluginId)
     id(libs.plugins.kotlin.android.core.get().pluginId)
     id(libs.plugins.gms.oss.licenses.plugin.get().pluginId)
-    kotlin("kapt")
+    alias(libs.plugins.ksp)
     alias(libs.plugins.dagger.hilt.android.core)
 }
 
@@ -62,7 +62,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android.core)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.work)
 
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
@@ -72,8 +72,4 @@ dependencies {
 
     // Running test with suspend functions
     testImplementation(libs.kotlinx.coroutines.test)
-}
-
-kapt {
-    correctErrorTypes = true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ buildscript {
 }
 plugins {
     alias(libs.plugins.detekt)
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.dagger.hilt.android.core) apply false
 }
 // see https://detekt.dev/docs/introduction/reporting/#merging-reports

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ detekt = "1.23.5"
 hilt = "2.56.2"
 agp = "8.10.0"
 gms-oss-licenses = "0.10.6"
+ksp = "2.1.20-2.0.1"
 
 [libraries]
 android-tools-build-gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
@@ -40,6 +41,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dagger-hilt-android-core = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android-core = { id = "kotlin-android", version.ref = "kotlin" }


### PR DESCRIPTION
## 概要

closes #62

Kapt の利用をやめて KSP を使うようにします。

参考: https://developer.android.com/build/migrate-to-ksp?hl=ja

## 動作確認

- アプリが起動すること
- 通知設定画面が開けること
- Twitter アカウントでログインできること